### PR TITLE
Fixed pause "preserve speed" checkbox state

### DIFF
--- a/src/view/components/editor/PauseAddControl.tsx
+++ b/src/view/components/editor/PauseAddControl.tsx
@@ -47,6 +47,12 @@ export const PauseAddControl: Preact.FunctionComponent<{
     }
   }, [open]);
 
+  useEffect(() => {
+    if (speedModified !== preserve) {
+      set_preserve(speedModified);
+    }
+  }, [speedModified]);
+
   const modal = (
     <div className="modal-backdrop">
       <div className="modal tts-pause-modal">


### PR DESCRIPTION
Fixed bug where pause preserve checkbox wouldn't update when toggling speed modifier